### PR TITLE
Lock Orientation to Portrait

### DIFF
--- a/app/src/main/java/com/cornellappdev/uplift/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.cornellappdev.uplift
 
 import android.content.Context
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -8,6 +9,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.cornellappdev.uplift.models.DatastoreRepository
 import com.cornellappdev.uplift.ui.MainNavigationWrapper
 import com.cornellappdev.uplift.ui.theme.UpliftTheme
+import com.cornellappdev.uplift.util.LockScreenOrientation
 import com.cornellappdev.uplift.util.PREFERENCES_NAME
 
 // Singleton
@@ -24,6 +26,7 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             UpliftTheme {
+                LockScreenOrientation(orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
                 MainNavigationWrapper()
             }
         }

--- a/app/src/main/java/com/cornellappdev/uplift/util/LockScreenOrientation.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/util/LockScreenOrientation.kt
@@ -1,0 +1,37 @@
+package com.cornellappdev.uplift.util
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Locks the screen orientation in the composable this function is present in to the
+ * given orientation.
+ *
+ * @param orientation The orientation (e.g. ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE) to lock.
+ */
+@Composable
+fun LockScreenOrientation(orientation: Int) {
+    val context = LocalContext.current
+    DisposableEffect(Unit) {
+        val activity = context.findActivity() ?: return@DisposableEffect onDispose {}
+        val originalOrientation = activity.requestedOrientation
+        activity.requestedOrientation = orientation
+        onDispose {
+            // restore original orientation when view disappears
+            activity.requestedOrientation = originalOrientation
+        }
+    }
+}
+
+/**
+ * Finds the current activity of the local context.
+ */
+private fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}


### PR DESCRIPTION
## Overview:

Tiny PR to lock the app orientation to portrait. The app crashes whenever going to landscape and should not even be used in landscape mode.

## Changes:

- Adds a function `LockScreenOrientation()` to lock the screen orientation to the given orientation.
- Locks the overarching activity to portrait.