### PR TITLE
Image loading fixes

### DIFF
--- a/app/src/main/java/com/cornellappdev/uplift/networking/CoilRepository.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/networking/CoilRepository.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.graphics.drawable.toBitmap
 import coil.imageLoader
-import coil.request.CachePolicy
 import coil.request.ImageRequest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,11 +32,6 @@ object CoilRepository {
         if (!urlMap.containsKey(imageUrl) || urlMap[imageUrl]!!.value is ApiResponse.Error) {
             val imageRequest = ImageRequest.Builder(context)
                 .data(imageUrl)
-                .memoryCacheKey(imageUrl)
-                .diskCacheKey(imageUrl)
-                .diskCachePolicy(CachePolicy.ENABLED)
-                .memoryCachePolicy(CachePolicy.ENABLED)
-                .crossfade(200)
                 .build()
 
             urlMap[imageUrl] = mutableStateOf(ApiResponse.Loading)

--- a/app/src/main/java/com/cornellappdev/uplift/ui/components/home/HomeCard.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/components/home/HomeCard.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.uplift.ui.components.home
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -85,21 +86,32 @@ fun HomeCard(gym: UpliftGym, onClick: () -> Unit) {
                     .alpha(if (isCurrentlyOpen(gym.hours[day])) 1f else .6f)
             ) {
                 Box(modifier = Modifier.fillMaxSize()) {
-                    Image(
-                        bitmap = if (bitmapState.value is ApiResponse.Success) {
-                            (bitmapState.value as ApiResponse.Success<ImageBitmap>).data
-                        } else {
-                            ImageBitmap(height = 1, width = 1)
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .then(
-                                if (bitmapState.value !is ApiResponse.Success) Modifier
-                                    .background(colorInterp(progress, GRAY01, GRAY03)) else Modifier
-                            ),
-                        contentDescription = "",
-                        contentScale = ContentScale.Crop,
-                    )
+                    Crossfade(
+                        targetState = bitmapState.value,
+                        label = "imageFade",
+                        animationSpec = tween(250)
+                    ) { apiResponse ->
+                        when (apiResponse) {
+                            is ApiResponse.Success ->
+                                Image(
+                                    bitmap = apiResponse.data,
+                                    modifier = Modifier.fillMaxWidth(),
+                                    contentDescription = "",
+                                    contentScale = ContentScale.Crop
+                                )
+
+                            else ->
+                                Image(
+                                    bitmap = ImageBitmap(width = 1, height = 1),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(colorInterp(progress, GRAY01, GRAY03)),
+                                    contentDescription = "",
+                                    contentScale = ContentScale.Crop
+                                )
+                        }
+                    }
+
 
                     Box(
                         modifier = Modifier

--- a/app/src/main/java/com/cornellappdev/uplift/ui/components/home/HomeCard.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/components/home/HomeCard.kt
@@ -112,7 +112,6 @@ fun HomeCard(gym: UpliftGym, onClick: () -> Unit) {
                         }
                     }
 
-
                     Box(
                         modifier = Modifier
                             .align(TopEnd)

--- a/app/src/main/java/com/cornellappdev/uplift/ui/screens/ClassDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/screens/ClassDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.cornellappdev.uplift.ui.screens
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -108,25 +109,40 @@ fun ClassDetailScreen(
                 translationY = 0.5f * scrollState.value
             }
         ) {
-            Image(
-                bitmap = if (bitmapState.value is ApiResponse.Success) {
-                    (bitmapState.value as ApiResponse.Success<ImageBitmap>).data
-                } else {
-                    ImageBitmap(height = 1, width = 1)
-                },
-                contentDescription = null,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(1f)
-                    .graphicsLayer {
-                        alpha = 1 - (scrollState.value.toFloat() / screenHeightPx)
-                    }
-                    .then(
-                        if (bitmapState.value !is ApiResponse.Success) Modifier
-                            .background(colorInterp(progress, GRAY01, GRAY03)) else Modifier
-                    ),
-                contentScale = ContentScale.Crop
-            )
+            Crossfade(
+                targetState = bitmapState.value,
+                label = "imageFade",
+                animationSpec = tween(250)
+            ) { apiResponse ->
+                when (apiResponse) {
+                    is ApiResponse.Success ->
+                        Image(
+                            bitmap = apiResponse.data,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1f)
+                                .graphicsLayer {
+                                    alpha = 1 - (scrollState.value.toFloat() / screenHeightPx)
+                                },
+                            contentScale = ContentScale.Crop,
+                        )
+
+                    else ->
+                        Image(
+                            bitmap = ImageBitmap(height = 1, width = 1),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1f)
+                                .graphicsLayer {
+                                    alpha = 1 - (scrollState.value.toFloat() / screenHeightPx)
+                                }
+                                .background(colorInterp(progress, GRAY01, GRAY03)),
+                            contentScale = ContentScale.Crop,
+                        )
+                }
+            }
             Icon(
                 painter = painterResource(id = R.drawable.ic_back_arrow),
                 contentDescription = null,

--- a/app/src/main/java/com/cornellappdev/uplift/ui/screens/GymDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/screens/GymDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.cornellappdev.uplift.ui.screens
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -107,25 +108,40 @@ fun GymDetailScreen(
                 translationY = 0.5f * scrollState.value
             })
         {
-            Image(
-                bitmap = if (bitmapState.value is ApiResponse.Success) {
-                    (bitmapState.value as ApiResponse.Success<ImageBitmap>).data
-                } else {
-                    ImageBitmap(height = 1, width = 1)
-                },
-                contentDescription = null,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(1f)
-                    .graphicsLayer {
-                        alpha = 1 - (scrollState.value.toFloat() / screenHeightPx)
-                    }
-                    .then(
-                        if (bitmapState.value !is ApiResponse.Success) Modifier
-                            .background(colorInterp(progress, GRAY01, GRAY03)) else Modifier
-                    ),
-                contentScale = ContentScale.Crop,
-            )
+            Crossfade(
+                targetState = bitmapState.value,
+                label = "imageFade",
+                animationSpec = tween(250)
+            ) { apiResponse ->
+                when (apiResponse) {
+                    is ApiResponse.Success ->
+                        Image(
+                            bitmap = apiResponse.data,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1f)
+                                .graphicsLayer {
+                                    alpha = 1 - (scrollState.value.toFloat() / screenHeightPx)
+                                },
+                            contentScale = ContentScale.Crop,
+                        )
+
+                    else ->
+                        Image(
+                            bitmap = ImageBitmap(height = 1, width = 1),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1f)
+                                .graphicsLayer {
+                                    alpha = 1 - (scrollState.value.toFloat() / screenHeightPx)
+                                }
+                                .background(colorInterp(progress, GRAY01, GRAY03)),
+                            contentScale = ContentScale.Crop,
+                        )
+                }
+            }
             Icon(
                 painter = painterResource(id = R.drawable.ic_back_arrow),
                 contentDescription = null,


### PR DESCRIPTION
## Overview:

Some very small tweaks to image loading I figured would be good while I'm waiting for backend.

## Changes:
- Coil in-built caching is no longer being used because it sucks and I hate it (it doesn't work)
- Images now fade from not loaded to loaded smoothly on HomeCard and detail screens.

## Demo:

Images now load in smoothly.

https://github.com/cuappdev/uplift-android/assets/47724806/0f6e8e7e-837b-4795-84ff-407b8ce402c1

