### PR TITLE
Fix uplift classes not showing if identical times in future

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.cornellappdev.uplift"
         minSdk 30
         targetSdk 34
-        versionCode 1
-        versionName "1.0"
+        versionCode 3
+        versionName "1.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/cornellappdev/uplift/networking/UpliftApiRepository.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/networking/UpliftApiRepository.kt
@@ -1,6 +1,5 @@
 package com.cornellappdev.uplift.networking
 
-import android.util.Log
 import com.apollographql.apollo3.ApolloClient
 import com.cornellappdev.uplift.models.UpliftClass
 import com.cornellappdev.uplift.models.UpliftGym
@@ -20,7 +19,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import java.util.Calendar
 
 /**
  * A repository dealing with all API backend connection in Uplift.
@@ -113,10 +111,6 @@ object UpliftApiRepository {
 
                         val upliftClasses =
                             classList.mapNotNull { query -> query.first!!.toUpliftClass(query.second) }
-
-                        Log.d("classes", upliftClasses.map {
-                            it.date.get(Calendar.DAY_OF_MONTH)
-                        }.toString())
 
                         ApiResponse.Success(
                             upliftClasses.distinctBy { upliftClass ->

--- a/app/src/main/java/com/cornellappdev/uplift/networking/UpliftApiRepository.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/networking/UpliftApiRepository.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.uplift.networking
 
+import android.util.Log
 import com.apollographql.apollo3.ApolloClient
 import com.cornellappdev.uplift.models.UpliftClass
 import com.cornellappdev.uplift.models.UpliftGym
@@ -19,6 +20,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import java.util.Calendar
 
 /**
  * A repository dealing with all API backend connection in Uplift.
@@ -108,14 +110,21 @@ object UpliftApiRepository {
                                     )
                                 }
                             }.flatten().filter { pair -> pair.first != null }
+
                         val upliftClasses =
                             classList.mapNotNull { query -> query.first!!.toUpliftClass(query.second) }
+
+                        Log.d("classes", upliftClasses.map {
+                            it.date.get(Calendar.DAY_OF_MONTH)
+                        }.toString())
+
                         ApiResponse.Success(
                             upliftClasses.distinctBy { upliftClass ->
-                                Triple(
+                                listOf(
                                     upliftClass.name,
                                     upliftClass.location,
-                                    upliftClass.time
+                                    upliftClass.time,
+                                    upliftClass.date
                                 )
                             }
                         )

--- a/app/src/main/java/com/cornellappdev/uplift/ui/components/gymdetail/GymCapacitiesSection.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/components/gymdetail/GymCapacitiesSection.kt
@@ -19,8 +19,11 @@ import com.cornellappdev.uplift.ui.components.home.GymCapacity
 import com.cornellappdev.uplift.util.PRIMARY_BLACK
 import com.cornellappdev.uplift.util.montserratFamily
 
+/**
+ * The Gym Detail's Capacity section.
+ */
 @Composable
-fun GymCapacitiesSection(capacity: UpliftCapacity) {
+fun GymCapacitiesSection(closed: Boolean, capacity: UpliftCapacity?) {
     Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Spacer(modifier = Modifier.height(14.dp))
         // Title
@@ -37,7 +40,8 @@ fun GymCapacitiesSection(capacity: UpliftCapacity) {
         Row(modifier = Modifier.padding(top = 18.dp, bottom = 24.dp)) {
             GymCapacity(
                 capacity = capacity,
-                label = capacity.updatedString(),
+                label = capacity?.updatedString(),
+                closed = closed,
                 gymDetail = true
             )
         }

--- a/app/src/main/java/com/cornellappdev/uplift/ui/components/gymdetail/GymFacilitySection.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/components/gymdetail/GymFacilitySection.kt
@@ -38,7 +38,7 @@ import com.cornellappdev.uplift.ui.screens.LineSpacer
 import com.cornellappdev.uplift.util.ACCENT_CLOSED
 import com.cornellappdev.uplift.util.ACCENT_OPEN
 import com.cornellappdev.uplift.util.PRIMARY_BLACK
-import com.cornellappdev.uplift.util.isCurrentlyOpen
+import com.cornellappdev.uplift.util.isOpen
 import com.cornellappdev.uplift.util.montserratFamily
 
 /**
@@ -105,7 +105,7 @@ fun GymFacilitySection(gym: UpliftGym, today: Int) {
                     openedFacility = if (openedFacility == 2) -1 else 2
                 },
                 open = when (gym.gymnasiumInfo[today] != null
-                        && isCurrentlyOpen(gym.gymnasiumInfo[today]!!.hours)) {
+                        && isOpen(gym.gymnasiumInfo[today]!!.hours)) {
                     true -> OpenType.OPEN
                     else -> OpenType.CLOSED
                 }
@@ -125,7 +125,7 @@ fun GymFacilitySection(gym: UpliftGym, today: Int) {
                     openedFacility = if (openedFacility == 3) -1 else 3
                 },
                 open = when (gym.swimmingInfo[today] != null
-                        && isCurrentlyOpen(gym.swimmingInfo[today]!!.hours())) {
+                        && isOpen(gym.swimmingInfo[today]!!.hours())) {
                     true -> OpenType.OPEN
                     else -> OpenType.CLOSED
                 }
@@ -146,7 +146,7 @@ fun GymFacilitySection(gym: UpliftGym, today: Int) {
                     openedFacility = if (openedFacility == 4) -1 else 4
                 },
                 open = when (gym.bowlingInfo[today] != null
-                        && isCurrentlyOpen(gym.bowlingInfo[today]!!.hours)) {
+                        && isOpen(gym.bowlingInfo[today]!!.hours)) {
                     true -> OpenType.OPEN
                     else -> OpenType.CLOSED
                 }

--- a/app/src/main/java/com/cornellappdev/uplift/ui/components/home/GymCapacity.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/components/home/GymCapacity.kt
@@ -36,14 +36,16 @@ import com.cornellappdev.uplift.util.montserratFamily
  *                  and whose second element is the max capacity.
  * @param label     The name of the gym placed under this indicator. Can be null to indicate no
  *                  label.
+ * @param closed    If this gym is closed.
  */
 @Composable
 fun GymCapacity(
-    capacity: UpliftCapacity,
+    capacity: UpliftCapacity?,
     label: String?,
+    closed: Boolean,
     gymDetail: Boolean = false
 ) {
-    val fraction = capacity.percent.toFloat()
+    val fraction = if (!closed && capacity != null) capacity.percent.toFloat() else 0f
     val animatedFraction = remember { Animatable(0f) }
 
     // When the composable launches, animate the fraction to the capacity fraction.
@@ -73,7 +75,8 @@ fun GymCapacity(
             )
 
     val size = if (gymDetail) 104.5.dp else 72.dp
-    val percentFontSize = if (gymDetail) 17.sp else 12.sp
+    val percentFontSize =
+        (if (gymDetail) 17.sp else 12.sp) * (if (closed || capacity != null) 1f else .9f)
     val labelColor = if (gymDetail) GRAY04 else PRIMARY_BLACK
     val labelFontWeight = if (gymDetail) FontWeight(300) else FontWeight(600)
     val labelPadding = if (gymDetail) 9.dp else 12.dp
@@ -94,11 +97,12 @@ fun GymCapacity(
                 strokeCap = StrokeCap.Round
             )
             Text(
-                text = capacity.percentString(),
+                text = if (closed) "CLOSED"
+                else capacity?.percentString() ?: "NO DATA",
                 fontFamily = montserratFamily,
                 fontSize = percentFontSize,
                 fontWeight = FontWeight(700),
-                color = PRIMARY_BLACK,
+                color = if (closed || capacity == null) GRAY02 else PRIMARY_BLACK,
                 modifier = Modifier.align(Alignment.Center),
                 textAlign = TextAlign.Center,
             )

--- a/app/src/main/java/com/cornellappdev/uplift/ui/components/home/HomeCard.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/components/home/HomeCard.kt
@@ -66,7 +66,7 @@ fun HomeCard(gym: UpliftGym, onClick: () -> Unit) {
         ),
         label = "homeCardLoading"
     )
-    val showGymCapacity = gym.upliftCapacity != null && isCurrentlyOpen(gym.hours[day]!!)
+    val showGymCapacity = gym.upliftCapacity != null && isOpen(gym.hours[day]!!)
 
     Box(
         modifier = Modifier
@@ -83,7 +83,7 @@ fun HomeCard(gym: UpliftGym, onClick: () -> Unit) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .alpha(if (isCurrentlyOpen(gym.hours[day])) 1f else .6f)
+                    .alpha(if (isOpen(gym.hours[day])) 1f else .6f)
             ) {
                 Box(modifier = Modifier.fillMaxSize()) {
                     Crossfade(
@@ -169,7 +169,7 @@ fun HomeCard(gym: UpliftGym, onClick: () -> Unit) {
                             }
                         }
                         Row {
-                            if (isCurrentlyOpen(gym.hours[day])) Text(
+                            if (isOpen(gym.hours[day])) Text(
                                 text = "Open",
                                 fontSize = 12.sp,
                                 color = ACCENT_OPEN,

--- a/app/src/main/java/com/cornellappdev/uplift/ui/screens/GymDetailScreen.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/screens/GymDetailScreen.kt
@@ -182,7 +182,7 @@ fun GymDetailScreen(
             )
 
             // CLOSED
-            if (gym != null && (gym!!.hours[day] == null || !isCurrentlyOpen(gym!!.hours[day]!!))) {
+            if (gym != null && (gym!!.hours[day] == null || !isOpen(gym!!.hours[day]!!))) {
                 Box(
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
@@ -209,16 +209,18 @@ fun GymDetailScreen(
         }
 
         if (gym != null) {
+            val closed = !isOpen(gym!!.hours[day])
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(Color.White)
             ) {
                 GymHours(hours = gym!!.hours, day)
-                if (gym!!.upliftCapacity != null) {
-                    LineSpacer()
-                    GymCapacitiesSection(gym!!.upliftCapacity!!)
-                }
+                LineSpacer()
+                GymCapacitiesSection(
+                    capacity = gym!!.upliftCapacity,
+                    closed = closed
+                )
                 if (gym!!.popularTimes.isNotEmpty()) {
                     LineSpacer()
                     PopularTimesSection(gym!!.popularTimes[day])

--- a/app/src/main/java/com/cornellappdev/uplift/ui/screens/subscreens/MainLoaded.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/screens/subscreens/MainLoaded.kt
@@ -70,7 +70,7 @@ import com.cornellappdev.uplift.util.GRAY04
 import com.cornellappdev.uplift.util.PRIMARY_YELLOW
 import com.cornellappdev.uplift.util.asTimeOfDay
 import com.cornellappdev.uplift.util.colorInterp
-import com.cornellappdev.uplift.util.isCurrentlyOpen
+import com.cornellappdev.uplift.util.isOpen
 import com.cornellappdev.uplift.util.montserratFamily
 import com.cornellappdev.uplift.util.todayIndex
 import kotlinx.coroutines.launch
@@ -91,9 +91,9 @@ fun MainLoaded(
     onToggleCapacities: () -> Unit,
 ) {
     val gymComparator = { gym1: UpliftGym, gym2: UpliftGym ->
-        if (isCurrentlyOpen(gym1.hours[todayIndex()]) && !isCurrentlyOpen(gym2.hours[todayIndex()])) {
+        if (isOpen(gym1.hours[todayIndex()]) && !isOpen(gym2.hours[todayIndex()])) {
             -1
-        } else if (!isCurrentlyOpen(gym1.hours[todayIndex()]) && isCurrentlyOpen(
+        } else if (!isOpen(gym1.hours[todayIndex()]) && isOpen(
                 gym2.hours[todayIndex()]
             )
         ) {
@@ -249,66 +249,67 @@ fun MainLoaded(
                                 .padding(top = 12.dp, bottom = 24.dp),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
-                            gyms.filter { gym -> gym.upliftCapacity != null }
-                                .let { gymsWithCapacities ->
-                                    // Place two capacities per row, or one if it's the last row and only 1 is left.
-                                    val bound = (gymsWithCapacities.size / 2f).roundToInt()
-                                    for (i in 0 until bound) {
-                                        Row(
+                            gyms.let { gymsWithCapacities ->
+                                // Place two capacities per row, or one if it's the last row and only 1 is left.
+                                val bound = (gymsWithCapacities.size / 2f).roundToInt()
+                                for (i in 0 until bound) {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 30.dp),
+                                        horizontalArrangement = Arrangement.SpaceEvenly
+                                    ) {
+                                        // First index [i * 2] should always exist.
+                                        Box(
                                             modifier = Modifier
-                                                .fillMaxWidth()
-                                                .padding(horizontal = 30.dp),
-                                            horizontalArrangement = Arrangement.SpaceEvenly
+                                                .padding(16.dp)
+                                                .widthIn(min = 143.dp)
+                                                .clickable(
+                                                    indication = null,
+                                                    interactionSource = MutableInteractionSource()
+                                                ) {
+                                                    navController.navigateToGym(
+                                                        gymDetailViewModel = gymDetailViewModel,
+                                                        gym = gymsWithCapacities[i * 2]
+                                                    )
+                                                },
+                                            contentAlignment = Alignment.Center
                                         ) {
-                                            // First index [i * 2] should always exist.
+                                            GymCapacity(
+                                                capacity = gymsWithCapacities[i * 2].upliftCapacity,
+                                                label = gymsWithCapacities[i * 2].name,
+                                                closed = !isOpen(gymsWithCapacities[i * 2].hours[todayIndex()])
+                                            )
+                                        }
+
+                                        // Second index [i * 2 + 1] may not exist.
+                                        if (i * 2 + 1 < gymsWithCapacities.size) {
                                             Box(
                                                 modifier = Modifier
                                                     .padding(16.dp)
                                                     .widthIn(min = 143.dp)
-                                                    .clickable(
-                                                        indication = null,
-                                                        interactionSource = MutableInteractionSource()
-                                                    ) {
+                                                    .clickable {
                                                         navController.navigateToGym(
                                                             gymDetailViewModel = gymDetailViewModel,
-                                                            gym = gymsWithCapacities[i * 2]
+                                                            gym = gymsWithCapacities[i * 2 + 1]
                                                         )
                                                     },
                                                 contentAlignment = Alignment.Center
                                             ) {
                                                 GymCapacity(
-                                                    capacity = gymsWithCapacities[i * 2].upliftCapacity!!,
-                                                    label = gymsWithCapacities[i * 2].name
+                                                    capacity = gymsWithCapacities[i * 2 + 1].upliftCapacity,
+                                                    label = gymsWithCapacities[i * 2 + 1].name,
+                                                    closed = !isOpen(gymsWithCapacities[i * 2].hours[todayIndex()])
                                                 )
                                             }
-
-                                            // Second index [i * 2 + 1] may not exist.
-                                            if (i * 2 + 1 < gymsWithCapacities.size) {
-                                                Box(
-                                                    modifier = Modifier
-                                                        .padding(16.dp)
-                                                        .widthIn(min = 143.dp)
-                                                        .clickable {
-                                                            navController.navigateToGym(
-                                                                gymDetailViewModel = gymDetailViewModel,
-                                                                gym = gymsWithCapacities[i * 2 + 1]
-                                                            )
-                                                        },
-                                                    contentAlignment = Alignment.Center
-                                                ) {
-                                                    GymCapacity(
-                                                        capacity = gymsWithCapacities[i * 2 + 1].upliftCapacity!!,
-                                                        label = gymsWithCapacities[i * 2 + 1].name
-                                                    )
-                                                }
-                                            }
-                                        }
-
-                                        if (i != bound - 1) {
-                                            Spacer(modifier = Modifier.height(12.dp))
                                         }
                                     }
+
+                                    if (i != bound - 1) {
+                                        Spacer(modifier = Modifier.height(12.dp))
+                                    }
                                 }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/cornellappdev/uplift/util/Functions.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/util/Functions.kt
@@ -104,7 +104,7 @@ fun getSystemTime(): TimeOfDay {
  * at [timeOfDay]. If [timeOfDay] is not passed a value, it defaults to the system time
  * retrieved by [getSystemTime].
  */
-fun isCurrentlyOpen(times: List<TimeInterval>?, timeOfDay: TimeOfDay = getSystemTime()): Boolean {
+fun isOpen(times: List<TimeInterval>?, timeOfDay: TimeOfDay = getSystemTime()): Boolean {
     if (times == null) return false
 
     val activeInterval = times.find { interval -> interval.within(timeOfDay) }


### PR DESCRIPTION
## Overview:

Some bug fixes and tweaks relating to classes and capacities.

## Changes:
- Uplift Classes will now correctly differentiate themselves if on different days, meaning classes will now correctly show up past their first occurrence.
- Capacities will show when a gym is CLOSED instead of simply hiding.
- Capacities will show NO DATA when a gym has no capacity data instead of simply hiding.