### PR TITLE
Fix capacity second thing not displaying closed correctly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.cornellappdev.uplift"
         minSdk 30
         targetSdk 34
-        versionCode 3
-        versionName "1.0.1"
+        versionCode 5
+        versionName "1.1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/cornellappdev/uplift/ui/screens/subscreens/MainLoaded.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/screens/subscreens/MainLoaded.kt
@@ -298,7 +298,7 @@ fun MainLoaded(
                                                 GymCapacity(
                                                     capacity = gymsWithCapacities[i * 2 + 1].upliftCapacity,
                                                     label = gymsWithCapacities[i * 2 + 1].name,
-                                                    closed = !isOpen(gymsWithCapacities[i * 2].hours[todayIndex()])
+                                                    closed = !isOpen(gymsWithCapacities[i * 2 + 1].hours[todayIndex()])
                                                 )
                                             }
                                         }


### PR DESCRIPTION
## Overview:

One-line fix to make capacity openness display correctly on the popup on the home screen.

