### PR TITLE
Onboarding Photo Picker Component

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
     implementation 'androidx.compose.material:material:1.5.1'
     implementation 'androidx.core:core-ktx:+'
+    implementation 'androidx.compose.material3:material3-android:1.3.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/java/com/cornellappdev/uplift/ui/components/onboarding/PhotoPicker.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/components/onboarding/PhotoPicker.kt
@@ -1,0 +1,131 @@
+package com.cornellappdev.uplift.ui.components.onboarding
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.cornellappdev.uplift.util.GRAY01
+import com.cornellappdev.uplift.R
+
+/***
+ * Component that displays a camera icon for the user to select a photo for their profile
+ *  @param onPhotoSelected: function to call when the user selects a photo. Takes in uri parameter
+ */
+@Composable
+fun PhotoPicker(onPhotoSelected: (Uri) -> Unit){
+    // State to store the selected image URI
+    var selectedImageUri by rememberSaveable { mutableStateOf<Uri?>(null) }
+
+    // Registers a photo picker activity launcher in single-select mode.
+    val pickMedia = rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+        // Callback is invoked after the user selects a media item or closes the
+        // photo picker.
+        if (uri != null) {
+            selectedImageUri = uri
+            onPhotoSelected(uri)
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .size(160.dp),
+        contentAlignment = Alignment.Center
+    ){
+        ElevatedCard(
+            elevation = CardDefaults.cardElevation(
+                defaultElevation = 10.dp
+            ),
+            colors = CardDefaults.cardColors(
+                containerColor = Color.White,
+            ),
+            shape = CircleShape,
+            modifier = Modifier
+                .size(160.dp),
+            onClick = {
+                // Launch the photo picker and let the user choose only images.
+                pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            }
+        ){
+            Box(
+                modifier = Modifier
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ){
+                // Check if a photo is selected, and display it, otherwise show the camera icon
+                if (selectedImageUri != null) {
+                    Image(
+                        painter = rememberAsyncImagePainter(selectedImageUri),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(144.dp)
+                            .clip(CircleShape)
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .size(144.dp)
+                            .clip(CircleShape)
+                            .background(GRAY01),
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.ic_camera),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(top = 16.dp)
+                        )
+                    }
+                }
+            }
+        }
+        // If a photo is selected, display the camera icon on top of the photo
+        if (selectedImageUri != null) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_camera_circle),
+                contentDescription = null,
+                modifier = Modifier
+                    .offset(60.dp, 64.dp)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PhotoPickerPreview() {
+        Column(
+            modifier = Modifier
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ){
+            PhotoPicker {}
+        }
+}

--- a/app/src/main/java/com/cornellappdev/uplift/ui/components/onboarding/PhotoPicker.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/components/onboarding/PhotoPicker.kt
@@ -38,45 +38,35 @@ import com.cornellappdev.uplift.R
  *  @param onPhotoSelected: function to call when the user selects a photo. Takes in uri parameter
  */
 @Composable
-fun PhotoPicker(onPhotoSelected: (Uri) -> Unit){
+fun PhotoPicker(imageUri: Uri? = null, onPhotoSelected: (Uri) -> Unit) {
     // State to store the selected image URI
-    var selectedImageUri by rememberSaveable { mutableStateOf<Uri?>(null) }
+    var selectedImageUri by rememberSaveable { mutableStateOf<Uri?>(imageUri) }
 
     // Registers a photo picker activity launcher in single-select mode.
-    val pickMedia = rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
-        // Callback is invoked after the user selects a media item or closes the
-        // photo picker.
-        if (uri != null) {
-            selectedImageUri = uri
-            onPhotoSelected(uri)
+    val pickMedia =
+        rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+            // Callback is invoked after the user selects a media item or closes the
+            // photo picker.
+            if (uri != null) {
+                selectedImageUri = uri
+                onPhotoSelected(uri)
+            }
         }
-    }
 
     Box(
-        modifier = Modifier
-            .size(160.dp),
-        contentAlignment = Alignment.Center
-    ){
-        ElevatedCard(
-            elevation = CardDefaults.cardElevation(
-                defaultElevation = 10.dp
-            ),
-            colors = CardDefaults.cardColors(
-                containerColor = Color.White,
-            ),
-            shape = CircleShape,
-            modifier = Modifier
-                .size(160.dp),
-            onClick = {
-                // Launch the photo picker and let the user choose only images.
-                pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
-            }
-        ){
+        modifier = Modifier.size(160.dp), contentAlignment = Alignment.Center
+    ) {
+        ElevatedCard(elevation = CardDefaults.cardElevation(
+            defaultElevation = 10.dp
+        ), colors = CardDefaults.cardColors(
+            containerColor = Color.White,
+        ), shape = CircleShape, modifier = Modifier.size(160.dp), onClick = {
+            // Launch the photo picker and let the user choose only images.
+            pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+        }) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ){
+                modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center
+            ) {
                 // Check if a photo is selected, and display it, otherwise show the camera icon
                 if (selectedImageUri != null) {
                     Image(
@@ -110,8 +100,7 @@ fun PhotoPicker(onPhotoSelected: (Uri) -> Unit){
             Image(
                 painter = painterResource(id = R.drawable.ic_camera_circle),
                 contentDescription = null,
-                modifier = Modifier
-                    .offset(60.dp, 64.dp)
+                modifier = Modifier.offset(60.dp, 64.dp)
             )
         }
     }
@@ -120,12 +109,11 @@ fun PhotoPicker(onPhotoSelected: (Uri) -> Unit){
 @Preview(showBackground = true)
 @Composable
 private fun PhotoPickerPreview() {
-        Column(
-            modifier = Modifier
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
-        ){
-            PhotoPicker {}
-        }
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        PhotoPicker {}
+    }
 }

--- a/app/src/main/java/com/cornellappdev/uplift/ui/components/onboarding/PhotoPicker.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/components/onboarding/PhotoPicker.kt
@@ -33,14 +33,14 @@ import coil.compose.rememberAsyncImagePainter
 import com.cornellappdev.uplift.util.GRAY01
 import com.cornellappdev.uplift.R
 
-/***
+/**
  * Component that displays a camera icon for the user to select a photo for their profile
  *  @param onPhotoSelected: function to call when the user selects a photo. Takes in uri parameter
  */
 @Composable
 fun PhotoPicker(imageUri: Uri? = null, onPhotoSelected: (Uri) -> Unit) {
     // State to store the selected image URI
-    var selectedImageUri by rememberSaveable { mutableStateOf<Uri?>(imageUri) }
+    var selectedImageUri by rememberSaveable { mutableStateOf(imageUri) }
 
     // Registers a photo picker activity launcher in single-select mode.
     val pickMedia =
@@ -56,16 +56,23 @@ fun PhotoPicker(imageUri: Uri? = null, onPhotoSelected: (Uri) -> Unit) {
     Box(
         modifier = Modifier.size(160.dp), contentAlignment = Alignment.Center
     ) {
-        ElevatedCard(elevation = CardDefaults.cardElevation(
-            defaultElevation = 10.dp
-        ), colors = CardDefaults.cardColors(
-            containerColor = Color.White,
-        ), shape = CircleShape, modifier = Modifier.size(160.dp), onClick = {
-            // Launch the photo picker and let the user choose only images.
-            pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
-        }) {
+        ElevatedCard(
+            elevation = CardDefaults.cardElevation(defaultElevation = 10.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            shape = CircleShape,
+            modifier = Modifier.size(160.dp),
+            onClick = {
+                // Launch the photo picker and let the user choose only images.
+                pickMedia.launch(
+                    PickVisualMediaRequest(
+                        ActivityResultContracts.PickVisualMedia.ImageOnly
+                    )
+                )
+            }
+        ) {
             Box(
-                modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
             ) {
                 // Check if a photo is selected, and display it, otherwise show the camera icon
                 if (selectedImageUri != null) {

--- a/app/src/main/res/drawable/ic_camera.xml
+++ b/app/src/main/res/drawable/ic_camera.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="156dp"
+    android:height="145dp"
+    android:viewportWidth="156"
+    android:viewportHeight="145">
+  <path
+      android:pathData="M40.5,84.91V51.84C40.5,46.66 44.7,42.46 49.88,42.46H55.1C56.99,42.46 58.66,41.25 59.25,39.45L60.94,34.3C61.78,31.74 64.18,30 66.88,30H89.58C92.19,30 94.53,31.62 95.44,34.07L97.49,39.61C98.13,41.33 99.77,42.46 101.59,42.46H106.13C111.3,42.46 115.5,46.66 115.5,51.84V84.91C115.5,90.09 111.3,94.29 106.13,94.29H49.88C44.7,94.29 40.5,90.09 40.5,84.91Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M78.77,66.74m-14.72,0a14.72,14.72 0,1 1,29.44 0a14.72,14.72 0,1 1,-29.44 0"
+      android:strokeWidth="7.29167"
+      android:fillColor="#00000000"
+      android:strokeColor="#E5ECED"/>
+</vector>

--- a/app/src/main/res/drawable/ic_camera_circle.xml
+++ b/app/src/main/res/drawable/ic_camera_circle.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="121dp"
+    android:height="120dp"
+    android:viewportWidth="121"
+    android:viewportHeight="120">
+  <path
+      android:pathData="M60.5,30L60.5,30A20,20 0,0 1,80.5 50L80.5,50A20,20 0,0 1,60.5 70L60.5,70A20,20 0,0 1,40.5 50L40.5,50A20,20 0,0 1,60.5 30z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M48.5,56.57V45.99C48.5,44.33 49.84,42.99 51.5,42.99H53.17C53.78,42.99 54.31,42.6 54.5,42.02L55.04,40.38C55.31,39.56 56.08,39 56.94,39H64.2C65.04,39 65.79,39.52 66.08,40.3L66.74,42.08C66.94,42.62 67.46,42.99 68.05,42.99H69.5C71.16,42.99 72.5,44.33 72.5,45.99V56.57C72.5,58.23 71.16,59.57 69.5,59.57H51.5C49.84,59.57 48.5,58.23 48.5,56.57Z"
+      android:fillColor="#707070"/>
+  <path
+      android:pathData="M60.74,50.76m-4.71,0a4.71,4.71 0,1 1,9.42 0a4.71,4.71 0,1 1,-9.42 0"
+      android:strokeWidth="2.33333"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"/>
+</vector>


### PR DESCRIPTION
## Summary of Changes for Issue https://github.com/cuappdev/uplift-android/issues/51

-  Created PhotoPicker component for users to select photos for profile
-  Component takes in a function onPhotoSelected that will be called when user selects photo which will be displayed
-  Added white camera icon and circle camera icon as vector assets for component
-  Added dependency  [implementation 'androidx.compose.material3:material3-android:1.3.0'] for ElevatedCard component to make use of elevation property for shadow


### Demo
[PhotoPickerComponent.webm](https://github.com/user-attachments/assets/2660160e-87a0-4367-a202-71ab5b6b7126)

### Notes

- Encountered following error that might need to be addressed when building due to SportButton.kt and TabContentSelector.kt: 
- [Using 'rememberRipple(Boolean = ..., Dp = ..., Color = ...): Indication' is an error. rememberRipple has been deprecated - it returns an old Indication implementation that is not compatible with the new Indication APIs that provide notable performance improvements. Instead, use the new ripple APIs provided by design system libraries, such as material and material3. If you are implementing your own design system library, use createRippleNode to create your own custom ripple implementation that queries your own theme values. For a migration guide and background information, please visit developer.android.com]