### PR TITLE
Added ConfettiBurst to CheckInPopUp feature

### DIFF
--- a/app/src/main/java/com/cornellappdev/uplift/data/repositories/ConfettiRepository.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/data/repositories/ConfettiRepository.kt
@@ -1,0 +1,21 @@
+package com.cornellappdev.uplift.data.repositories
+
+import com.cornellappdev.uplift.ui.viewmodels.profile.ConfettiViewModel
+import com.cornellappdev.uplift.util.UIEvent
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+//Source:  Resell
+
+@Singleton
+class ConfettiRepository @Inject constructor() {
+    private val _showConfettiEvent: MutableStateFlow<UIEvent<ConfettiViewModel.ConfettiUiState>?> =
+        MutableStateFlow(null)
+    val showConfettiEvent = _showConfettiEvent.asStateFlow()
+
+    fun showConfetti (event: ConfettiViewModel.ConfettiUiState) {
+        _showConfettiEvent.value = UIEvent(event)
+    }
+}

--- a/app/src/main/java/com/cornellappdev/uplift/data/repositories/ConfettiRepository.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/data/repositories/ConfettiRepository.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.uplift.data.repositories
 
+import androidx.compose.ui.geometry.Rect
 import com.cornellappdev.uplift.ui.viewmodels.profile.ConfettiViewModel
 import com.cornellappdev.uplift.util.UIEvent
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,5 +18,12 @@ class ConfettiRepository @Inject constructor() {
 
     fun showConfetti (event: ConfettiViewModel.ConfettiUiState) {
         _showConfettiEvent.value = UIEvent(event)
+    }
+
+    private val _confettiBounds = MutableStateFlow<Rect?>(null)
+    val confettiBounds = _confettiBounds.asStateFlow()
+
+    fun setConfettiBounds(bounds: Rect?) {
+        _confettiBounds.value = bounds
     }
 }

--- a/app/src/main/java/com/cornellappdev/uplift/ui/MainNavigationWrapper.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/MainNavigationWrapper.kt
@@ -90,7 +90,7 @@ fun MainNavigationWrapper(
     val systemUiController: SystemUiController = rememberSystemUiController()
 
     val checkInUiState = checkInViewModel.collectUiStateValue()
-    var confettiBounds by remember { mutableStateOf<Rect?>(null) }
+    val confettiUiState = confettiViewModel.collectUiStateValue()
 
     val yourShimmerTheme = defaultShimmerTheme.copy(
         shaderColors = listOf(
@@ -275,7 +275,7 @@ fun MainNavigationWrapper(
                 ){
                     Box(
                         modifier = Modifier.onGloballyPositioned { coords ->
-                            confettiBounds = coords.boundsInRoot()
+                            confettiViewModel.setConfettiBounds(coords.boundsInRoot())
                         }
                     ){
                         CheckInPopUp(
@@ -290,7 +290,7 @@ fun MainNavigationWrapper(
                 }
                 ConfettiBurst(
                     confettiViewModel = confettiViewModel,
-                    originRectInRoot = confettiBounds,
+                    particleSpawningBounds = confettiUiState.confettiBounds,
                     modifier = Modifier
                 )
             }

--- a/app/src/main/java/com/cornellappdev/uplift/ui/MainNavigationWrapper.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/MainNavigationWrapper.kt
@@ -13,10 +13,15 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -31,6 +36,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.cornellappdev.uplift.ui.components.general.CheckInPopUp
+import com.cornellappdev.uplift.ui.components.general.ConfettiBurst
 import com.cornellappdev.uplift.ui.nav.BottomNavScreens
 import com.cornellappdev.uplift.ui.nav.popBackClass
 import com.cornellappdev.uplift.ui.nav.popBackGym
@@ -51,6 +57,7 @@ import com.cornellappdev.uplift.ui.viewmodels.gyms.GymDetailViewModel
 import com.cornellappdev.uplift.ui.viewmodels.nav.RootNavigationViewModel
 import com.cornellappdev.uplift.ui.viewmodels.profile.CheckInMode
 import com.cornellappdev.uplift.ui.viewmodels.profile.CheckInViewModel
+import com.cornellappdev.uplift.ui.viewmodels.profile.ConfettiViewModel
 import com.cornellappdev.uplift.util.PRIMARY_BLACK
 import com.cornellappdev.uplift.util.PRIMARY_YELLOW
 import com.cornellappdev.uplift.util.montserratFamily
@@ -74,6 +81,7 @@ fun MainNavigationWrapper(
 
 ) {
 
+    val confettiViewModel: ConfettiViewModel = hiltViewModel()
     val checkInViewModel: CheckInViewModel = hiltViewModel()
     val rootNavigationUiState = rootNavigationViewModel.collectUiStateValue()
     val startDestination = rootNavigationUiState.startDestination
@@ -82,6 +90,7 @@ fun MainNavigationWrapper(
     val systemUiController: SystemUiController = rememberSystemUiController()
 
     val checkInUiState = checkInViewModel.collectUiStateValue()
+    var confettiBounds by remember { mutableStateOf<Rect?>(null) }
 
     val yourShimmerTheme = defaultShimmerTheme.copy(
         shaderColors = listOf(
@@ -252,24 +261,37 @@ fun MainNavigationWrapper(
                 composable<UpliftRootRoute.Favorites> {}
             }
 
-            AnimatedVisibility(
-                visible = checkInUiState.showPopUp && isMainScreen(),
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .fillMaxWidth()
-                    .padding(
-                        start = 10.dp,
-                        end = 9.dp,
-                        bottom = it.calculateBottomPadding() + 13.dp
-                    )
-            ){
-                CheckInPopUp(
-                    gymName = checkInUiState.gymName,
-                    currentTimeText = checkInUiState.timeText,
-                    onDismiss = { checkInViewModel.onDismiss() },
-                    onCheckIn = { checkInViewModel.onCheckIn() },
-                    onClosePopUp = { checkInViewModel.onClose() },
-                    mode = checkInUiState.mode,
+            Box(modifier = Modifier.fillMaxSize()){
+                AnimatedVisibility(
+                    visible = checkInUiState.showPopUp && isMainScreen(),
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .padding(
+                            start = 10.dp,
+                            end = 9.dp,
+                            bottom = it.calculateBottomPadding() + 13.dp
+                        )
+                ){
+                    Box(
+                        modifier = Modifier.onGloballyPositioned { coords ->
+                            confettiBounds = coords.boundsInRoot()
+                        }
+                    ){
+                        CheckInPopUp(
+                            gymName = checkInUiState.gymName,
+                            currentTimeText = checkInUiState.timeText,
+                            onDismiss = checkInViewModel::onDismiss,
+                            onCheckIn = checkInViewModel::onCheckIn,
+                            onClosePopUp = checkInViewModel::onClose,
+                            mode = checkInUiState.mode,
+                        )
+                    }
+                }
+                ConfettiBurst(
+                    confettiViewModel = confettiViewModel,
+                    originRectInRoot = confettiBounds,
+                    modifier = Modifier
                 )
             }
 

--- a/app/src/main/java/com/cornellappdev/uplift/ui/components/general/ConfettiBurst.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/components/general/ConfettiBurst.kt
@@ -1,0 +1,160 @@
+package com.cornellappdev.uplift.ui.components.general
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.withTransform
+import com.cornellappdev.uplift.ui.theme.ConfettiColors
+import kotlinx.coroutines.delay
+import com.cornellappdev.uplift.ui.viewmodels.profile.ConfettiViewModel
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * Shape of a confetti particle used by [ConfettiBurst]
+ */
+enum class ConfettiShape { CIRCLE, RECTANGLE }
+
+/**
+ * UI state backing the Check-In pop-up
+ *
+ * @param start   Emission point where the particle spawns
+ * @param vx      Initial horizontal velocity. Positive is to the right.
+ * @param vy0     Initial vertical velocity (px/s). Negative values launch upward.
+ * @param size    Base size (px). Used as the radius for circles and scale for rectangles.
+ * @param color   Color for the particle.
+ * @param shape   Geometric shape to render for this particle.
+ * @param rotation Initial rotation (degrees).
+ */
+private data class ConfettiParticle2D(
+    val start: Offset,
+    val vx: Float,
+    val vy0: Float,
+    val size: Float,
+    val color: Color,
+    val shape: ConfettiShape,
+    val rotation: Float
+)
+
+@Composable
+fun ConfettiBurst(
+    confettiViewModel: ConfettiViewModel,
+    originRectInRoot: Rect?,
+    modifier: Modifier = Modifier,
+    particleCount: Int = 30,
+    colors: List<Color> = listOf(
+        ConfettiColors.Yellow1,
+        ConfettiColors.Yellow2,
+        ConfettiColors.Yellow3,
+        ConfettiColors.Yellow4
+    )
+) {
+    val uiState = confettiViewModel.collectUiStateValue()
+
+    if (!uiState.showing || originRectInRoot == null) {
+        return
+    }
+
+    val rect = originRectInRoot
+
+    var started by remember(uiState.showing) { mutableStateOf(false) }
+
+    LaunchedEffect(uiState.showing) {
+        if (uiState.showing) started = true
+    }
+    val progress by animateFloatAsState(
+        targetValue =  if (started) 1f else 0f,
+        animationSpec = tween(durationMillis = 1200, easing = LinearEasing),
+        label = "confettiProgress"
+    )
+
+    val particles = remember((uiState.showing)) {
+        List(particleCount) {
+            val x = Random.nextFloat() * rect.width + rect.left
+            val y = Random.nextFloat() * rect.height + rect.top
+            val start: Offset = Offset(x,y)
+            val angle = ((-90f + Random.nextFloat() * 110f) * Math.PI / 180f).toFloat()
+            val speed = Random.nextFloat() * 700f + 400f
+            val vx = cos(angle) * speed
+            val vy0 = sin(angle) * speed
+            val size = Random.nextInt(18, 34).toFloat()
+            ConfettiParticle2D(
+                start = start,
+                vx = vx,
+                vy0 = vy0,
+                size = size,
+                color = colors.random(),
+                shape = if (Random.nextFloat() < 0.25f) ConfettiShape.CIRCLE else ConfettiShape.RECTANGLE,
+                rotation = Random.nextFloat() * 360f
+            )
+        }
+    }
+
+
+    LaunchedEffect(uiState.showing) {
+        if (uiState.showing) {
+            delay(1300)
+            confettiViewModel.onAnimationFinished()
+        }
+    }
+
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val g = 1750f
+        val t = progress * 1.2f
+
+        particles.forEach { particle ->
+            val x = particle.start.x + particle.vx * t
+            val y = particle.start.y + (particle.vy0 * t + 0.5f * g * t * t)
+
+            val alpha = 1f - progress
+
+            val brush = Brush.linearGradient(
+                colors = colors,
+                start = Offset(x - particle.size * 0.8f, y- particle.size * 0.8f),
+                end = Offset(x + particle.size* 0.8f, y+ particle.size * 0.8f)
+            )
+
+            when (particle.shape) {
+                ConfettiShape.CIRCLE -> {
+                    drawCircle(
+                        brush = brush,
+                        radius = particle.size.toFloat(),
+                        center = Offset(x, y),
+                        alpha = alpha
+                    )
+                }
+
+                ConfettiShape.RECTANGLE -> {
+                    withTransform({
+                        rotate(degrees = particle.rotation, pivot = Offset(x, y))
+                    }) {
+                        drawRoundRect(
+                            brush = brush,
+                            topLeft = Offset(
+                                x - (particle.size / 8f),
+                                y - (particle.size / 2f)
+                            ),
+                            size = Size(
+                                width = particle.size * 0.6f,
+                                height = particle.size * 1.8f
+                            ),
+                            cornerRadius = CornerRadius(2f, 2f),
+                            alpha = alpha
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/cornellappdev/uplift/ui/components/general/ConfettiBurst.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/components/general/ConfettiBurst.kt
@@ -17,8 +17,6 @@ import androidx.compose.ui.graphics.drawscope.withTransform
 import com.cornellappdev.uplift.ui.theme.ConfettiColors
 import kotlinx.coroutines.delay
 import com.cornellappdev.uplift.ui.viewmodels.profile.ConfettiViewModel
-import com.google.android.play.core.integrity.x
-import com.google.android.play.integrity.internal.y
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.random.Random
@@ -85,8 +83,8 @@ fun ConfettiBurst(
 
     var started by remember(uiState.showing) { mutableStateOf(false) }
 
-    LaunchedEffect(uiState.showing) {
-        if (uiState.showing) started = true
+    LaunchedEffect(Unit) {
+        started = true
     }
 
     // Progress 0 to 1 over 1.2s, used as time 't' in the physics below
@@ -126,11 +124,9 @@ fun ConfettiBurst(
     }
 
 
-    LaunchedEffect(uiState.showing) {
-        if (uiState.showing) {
-            delay(1300)
-            confettiViewModel.onAnimationFinished()
-        }
+    LaunchedEffect(Unit) {
+        delay(1300)
+        confettiViewModel.onAnimationFinished()
     }
 
     //Renders ballistic motion + fade out for each particle

--- a/app/src/main/java/com/cornellappdev/uplift/ui/theme/Color.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/theme/Color.kt
@@ -15,3 +15,10 @@ object AppColors {
     val TextPrimary = Color(0xFF1B1F23)
     val Gray01 = Color(0xFFE5ECED)
 }
+
+object ConfettiColors{
+    val Yellow1 = Color(0xFFFFF176)
+    val Yellow2 = Color(0xFFFFEB3B)
+    val Yellow3 = Color(0xFFFFD54F)
+    val Yellow4 = Color(0xFFFFF59D)
+}

--- a/app/src/main/java/com/cornellappdev/uplift/ui/viewmodels/profile/CheckInViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/viewmodels/profile/CheckInViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.uplift.data.repositories.CheckInRepository
+import com.cornellappdev.uplift.data.repositories.ConfettiRepository
 import com.cornellappdev.uplift.data.repositories.LocationRepository
 import com.cornellappdev.uplift.ui.viewmodels.UpliftViewModel
 import com.cornellappdev.uplift.util.isOpen
@@ -37,14 +38,14 @@ data class CheckInUiState(
     val mode: CheckInMode = CheckInMode.Prompt,
     val gymId: String? = "",
     val gymName: String = "",
-    val timeText: String = "",
-    val showConfetti: Boolean = false
+    val timeText: String = ""
 )
 
 /** A [CheckInViewModel] manages state and actions for the Check-In pop-up on main screens. */
 @HiltViewModel
 class CheckInViewModel @Inject constructor(
     private val checkInRepository: CheckInRepository,
+    private val confettiRepository: ConfettiRepository
 ) : UpliftViewModel<CheckInUiState>(CheckInUiState()) {
 
     private var locationJob: Job? = null
@@ -127,7 +128,7 @@ class CheckInViewModel @Inject constructor(
     /**
      * Marks the user as checked in for the day, triggering a cooldown til the end of day and a
      * logworkout mutation through [checkInRepository]. On a successful call, transitions UI into
-     * [CheckInMode.Complete].
+     * [CheckInMode.Complete] and bursts confetti from popup through a [confettiRepository].
      *
      * Note: Temporarily skips over failed backend log workout call to keep functionality while auth and
      * sign in are not working.
@@ -148,6 +149,7 @@ class CheckInViewModel @Inject constructor(
                     mode = CheckInMode.Complete
                 )
             }
+            confettiRepository.showConfetti(ConfettiViewModel.ConfettiUiState())
             checkInRepository.logWorkoutFromCheckIn(gymIdInt)
         } catch (e: Exception) {
             Log.e(tag, "Error checking in", e)

--- a/app/src/main/java/com/cornellappdev/uplift/ui/viewmodels/profile/ConfettiViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/viewmodels/profile/ConfettiViewModel.kt
@@ -1,0 +1,43 @@
+package com.cornellappdev.uplift.ui.viewmodels.profile
+
+import com.cornellappdev.uplift.data.repositories.ConfettiRepository
+import com.cornellappdev.uplift.ui.viewmodels.UpliftViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+//Source:  Resell
+
+/** A [ConfettiViewModel] listens for confetti events and exposes animation state to the UI. */
+@HiltViewModel
+class ConfettiViewModel @Inject constructor(
+    confettiRepository: ConfettiRepository
+) :
+    UpliftViewModel<ConfettiViewModel.ConfettiUiState>(
+        initialUiState = ConfettiUiState()
+    ) {
+    data class ConfettiUiState(
+        val showing: Boolean = false
+    )
+
+    /** Sets UI state to show the confetti animation. */
+    fun onShow() {
+        applyMutation { copy(showing = true) }
+    }
+
+    /** Resets UI state after the animation completes to hide confetti. */
+    fun onAnimationFinished() {
+        applyMutation { copy(showing = false) }
+    }
+
+    init {
+        asyncCollect(confettiRepository.showConfettiEvent) { event ->
+            event?.consume {
+                applyMutation {
+                    copy(
+                        showing = true
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/cornellappdev/uplift/ui/viewmodels/profile/ConfettiViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/uplift/ui/viewmodels/profile/ConfettiViewModel.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.uplift.ui.viewmodels.profile
 
+import androidx.compose.ui.geometry.Rect
 import com.cornellappdev.uplift.data.repositories.ConfettiRepository
 import com.cornellappdev.uplift.ui.viewmodels.UpliftViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -10,13 +11,14 @@ import javax.inject.Inject
 /** A [ConfettiViewModel] listens for confetti events and exposes animation state to the UI. */
 @HiltViewModel
 class ConfettiViewModel @Inject constructor(
-    confettiRepository: ConfettiRepository
+    private val confettiRepository: ConfettiRepository
 ) :
     UpliftViewModel<ConfettiViewModel.ConfettiUiState>(
         initialUiState = ConfettiUiState()
     ) {
     data class ConfettiUiState(
-        val showing: Boolean = false
+        val showing: Boolean = false,
+        val confettiBounds: Rect? = null
     )
 
     /** Sets UI state to show the confetti animation. */
@@ -29,6 +31,10 @@ class ConfettiViewModel @Inject constructor(
         applyMutation { copy(showing = false) }
     }
 
+    fun setConfettiBounds(bounds: Rect?) {
+        confettiRepository.setConfettiBounds(bounds)
+    }
+
     init {
         asyncCollect(confettiRepository.showConfettiEvent) { event ->
             event?.consume {
@@ -38,6 +44,11 @@ class ConfettiViewModel @Inject constructor(
                     )
                 }
             }
+        }
+
+        asyncCollect(confettiRepository.confettiBounds) { rect ->
+            applyMutation { copy(confettiBounds = rect) }
+
         }
     }
 }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->
<!-- Your title should be able to summarize what changes you’ve made in one sentence. For example: “Exclude staff from the check for follows”. For stacked PRs, please indicate clearly in the title where in the stack you are. For example: “[Eatery Refactor][4/5] Converted all files to MVP model” -->
## Overview
<!-- Summarize your changes here. -->
Sourced and modified from Resell's falling confetti, ConfettiOverlay. 
Added a confetti animation that bursts from the Check-In Pop-Up on a successful check-in, using a physic-based burst. The effect is anchored to the pop-up's bounds and is triggered by a ConfettiEvent. 
## Changes Made
<!-- Include details of what your changes actually are and how it is intended to work. -->
UI
- Added ConfettiBurst composable that emits particles from the full pop-up rectangle with initial velocity and gravity for a natural burst and then fall arc/effect.
- Particles fade out as the animation completes
- Calls onAnimationFinished() from ConfettiRepository to end burst and hide UI

Integration
- wrapped CheckInPopUp with GloballyPositioned to capture its bounds via boundsInRoot() and passed that rectangle to ConfettiBurst
- CheckInViewModel triggers the confetti burst after a successful check in. 
## Testing
<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Tested manually/visually on emulator
## Related PRs or Issues
<!-- List related PRs against other branches/repositories. -->
#99 and cuappdev/resell-android#86
## Screenshots
<!-- This could include of screenshots of the new feature / proof that the changes work. -->
<details>
  <summary>Confetti Burst Demo </summary>
  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
</details>

[confettiBurstDemo.webm](https://github.com/user-attachments/assets/889ebc66-475f-4057-acae-459bace3f6cf)

